### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate PR


### PR DESCRIPTION
Potential fix for [https://github.com/manusoft/Ytdlp.NET/security/code-scanning/1](https://github.com/manusoft/Ytdlp.NET/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci-pr.yml` at the workflow root (recommended here since there is one job and all steps are read-only). The minimal required permission for this workflow is:

- `contents: read`

This preserves existing behavior (checkout + restore/build/test) while preventing unintended write scopes if defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
