### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     name: Run Integration Tests


### PR DESCRIPTION
Potential fix for [https://github.com/manusoft/Ytdlp.NET/security/code-scanning/2](https://github.com/manusoft/Ytdlp.NET/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` has only the minimum required scope.  
Best fix here: add `permissions: contents: read` at the workflow root (after `on:` and before `jobs:`), which applies to all jobs unless overridden. This preserves current functionality and satisfies CodeQL by explicitly constraining token privileges.

**File/region to change**
- `.github/workflows/ci-integration.yml`
- Insert a workflow-level permissions block between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
